### PR TITLE
Upgrade to allennlp==2.1.0

### DIFF
--- a/oos_detect/datasets/readers/oos_eval.py
+++ b/oos_detect/datasets/readers/oos_eval.py
@@ -100,7 +100,10 @@ class OOSEvalReader(DatasetReader):
         fields = {"sentence": sentence_field}
 
         # lab = LabelField(label)
-        fields["label"] = LabelField(label)
+        fields["label"] = LabelField(
+            label,
+            label_namespace="labels"
+        )
         # print(f"Just read: {lab.label}, {type(lab.label)}")
 
         return Instance(fields)

--- a/oos_detect/datasets/readers/oos_eval.py
+++ b/oos_detect/datasets/readers/oos_eval.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import numpy as np
+from pathlib import Path
 from allennlp.data import Instance
 from allennlp.data import DatasetReader
 from allennlp.data.tokenizers import Tokenizer
@@ -82,7 +83,8 @@ class OOSEvalReader(DatasetReader):
         self.token_indexers = token_indexers or {
             "tokens": PretrainedTransformerIndexer(
                 model_name="bert-base-uncased",
-                max_length=max_length
+                max_length=max_length,
+                namespace="tokens"
             )
         }
         self.tokenizer = tokenizer or PretrainedTransformerTokenizer(
@@ -97,7 +99,7 @@ class OOSEvalReader(DatasetReader):
     ) -> Instance:
         tokens = self.tokenizer.tokenize(sentence)
         sentence_field = TextField(tokens, self.token_indexers)
-        fields = {"sentence": sentence_field}
+        fields = {"tokens": sentence_field}
 
         # lab = LabelField(label)
         fields["label"] = LabelField(
@@ -124,8 +126,8 @@ class OOSEvalReader(DatasetReader):
         # fpath = self.path/(set_type + ".json")
 
         try:
-            # file_path.resolve(strict=True)
-            log.debug(file_path)
+            print(f"Looking for data in path: {file_path}")
+            Path(file_path).resolve(strict=True)
             # assert os.path.isfile(file_path)
 
         except FileNotFoundError as fe:

--- a/oos_detect/datasets/readers/oos_eval.py
+++ b/oos_detect/datasets/readers/oos_eval.py
@@ -5,10 +5,10 @@ from pathlib import Path
 from allennlp.data import Instance
 from allennlp.data import DatasetReader
 from allennlp.data.tokenizers import Tokenizer
+from typing import Dict, List, Iterator, Tuple
 from allennlp.data.token_indexers import TokenIndexer
 from allennlp.data.fields import LabelField, TextField
 from oos_detect.utilities.locate import locate_oos_data
-from typing import Dict, List, Iterator, Tuple, Iterable
 from oos_detect.utilities.exceptions import ReqdFileNotInSetError
 from oos_detect.utilities.exceptions import DataSetPortionMissingError
 from allennlp.data.tokenizers import PretrainedTransformerTokenizer
@@ -18,48 +18,24 @@ from allennlp.data.token_indexers import PretrainedTransformerIndexer
 log = logging.getLogger(__name__)
 
 
-def read_oos_data(
-        reader: DatasetReader,
+def oos_data_paths(
         set: str
-) -> Tuple[Tuple[Iterable[Instance], Iterable[Instance]], Iterable[Instance]]:
+) -> Tuple[Tuple[Path, Path], Path]:
     if set not in {"oos_plus", "imbalanced", "full", "small"}:
         print("Incorrect dataset mentioned, ending.")
         return
 
-    print(f"Reading the oos_{set} dataset.")
-    train_data = read_train_data(reader, set)
-    test_data = read_test_data(reader, set)
-
-    return train_data, test_data
-
-
-def read_train_data(
-        reader: DatasetReader,
-        set: str
-) -> Tuple[Iterable[Instance], Iterable[Instance]]:
+    print(f"Retrieving paths for oos_{set} dataset.")
     train_file_name = f"data_{set}_train.json"
     val_file_name = f"data_{set}_val.json"
-    print(f"Reading training & validation data from "
-          f"{train_file_name} and {val_file_name}.")
-
-    path = locate_oos_data()
-    training_data = reader.read(path/train_file_name)
-    validation_data = reader.read(path/val_file_name)
-
-    return training_data, validation_data
-
-
-def read_test_data(
-        reader: DatasetReader,
-        set: str
-) -> Tuple[Iterable[Instance], Iterable[Instance]]:
     test_file_name = f"data_{set}_test.json"
-    print(f"Reading test data from {test_file_name}.")
 
     path = locate_oos_data()
-    test_data = reader.read(path/test_file_name)
+    train_path = path/train_file_name
+    val_path = path/val_file_name
+    test_path = path/test_file_name
 
-    return test_data
+    return (train_path, val_path), test_path
 
 
 # @DatasetReader.register('oos-eval-reader')

--- a/oos_detect/models/bert_linear/builders.py
+++ b/oos_detect/models/bert_linear/builders.py
@@ -4,15 +4,12 @@ from allennlp.models import Model
 from allennlp.data import DataLoader
 from allennlp.data import Vocabulary
 from allennlp.training.trainer import Trainer
-from oos_detect.models.builders import build_epoch_callbacks
-from oos_detect.models.builders import build_batch_callbacks
-from allennlp.training.trainer import GradientDescentTrainer
-from oos_detect.models.bert_linear.classifier import BertLinearClassifier
-from allennlp.training.optimizers import HuggingfaceAdamWOptimizer
 from allennlp.modules.text_field_embedders import TextFieldEmbedder
 from allennlp.modules.seq2vec_encoders.bert_pooler import BertPooler
+from oos_detect.models.bert_linear.classifier import BertLinearClassifier
 from allennlp.modules.text_field_embedders import BasicTextFieldEmbedder
 from allennlp.modules.token_embedders import PretrainedTransformerEmbedder
+from oos_detect.models.builders import build_grad_desc_with_adam_trainer
 
 # Logger setup.
 log = logging.getLogger(__name__)
@@ -35,7 +32,7 @@ def bert_linear_builders(
     """
     model = build_model(vocab, wbrun)
 
-    trainer = build_trainer(
+    trainer = build_grad_desc_with_adam_trainer(
         model,
         serialization_dir,
         train_loader,
@@ -75,41 +72,3 @@ def build_model(vocab: Vocabulary, wbrun: Any) -> Model:
     log.debug("Encoder built.")
 
     return BertLinearClassifier(vocab, embedder, encoder, wbrun).cuda(0)
-
-
-def build_trainer(
-        model: Model,
-        serialization_dir: str,
-        train_loader: DataLoader,
-        dev_loader: DataLoader,
-        lr: float,
-        num_epochs: int,
-        wbrun: Any
-) -> Trainer:
-    """
-    Build the model trainer. Includes instantiating the optimizer as well.
-
-    :param model: The model object to be trained.
-    :param serialization_dir: The serialization directory to output
-            results to.
-    :param train_loader: The training data loader.
-    :param dev_loader: The dev data loader.
-    :return trainer: The Trainer object.
-    """
-    parameters = [
-        [n, p]
-        for n, p in model.named_parameters() if p.requires_grad
-    ]
-    optimizer = HuggingfaceAdamWOptimizer(parameters, lr=lr)
-    trainer = GradientDescentTrainer(
-        model=model,
-        serialization_dir=serialization_dir,
-        data_loader=train_loader,
-        validation_data_loader=dev_loader,
-        num_epochs=num_epochs,
-        optimizer=optimizer,
-        epoch_callbacks=build_epoch_callbacks(wbrun),
-        batch_callbacks=build_batch_callbacks(wbrun)
-    )
-
-    return trainer

--- a/oos_detect/models/bert_linear/classifier.py
+++ b/oos_detect/models/bert_linear/classifier.py
@@ -38,14 +38,14 @@ class BertLinearClassifier(Model):
 
     def forward(
             self,
-            example: TextFieldTensors,
-            target: torch.Tensor = None
+            tokens: TextFieldTensors,
+            label: torch.Tensor = None
     ) -> Dict[str, torch.Tensor]:
         # Shape: (batch_size, num_tokens, embedding_dim)
         # log.debug(f"Forward pass starting. Sentence Dict: {sentence!r}")
 
-        mask = util.get_text_field_mask(example)
-        embedded_text = self.embedder(example)
+        mask = util.get_text_field_mask(tokens)
+        embedded_text = self.embedder(tokens)
         # Shape: (batch_size, num_tokens)
         # mask = sentence["tokens"]["mask"]
 
@@ -66,9 +66,9 @@ class BertLinearClassifier(Model):
 
         # log.debug(f"Forward pass complete. Probabilities: {probs!r}")
 
-        if target is not None:
-            self.accuracy(logits, target)
-            output['loss'] = torch.nn.functional.cross_entropy(logits, target)
+        if label is not None:
+            self.accuracy(logits, label)
+            output['loss'] = torch.nn.functional.cross_entropy(logits, label)
             """log.debug("Calling wandb.log")
             wandb.log({
                 "loss": output['loss'],

--- a/oos_detect/models/builders.py
+++ b/oos_detect/models/builders.py
@@ -9,6 +9,7 @@ from allennlp.training.trainer import EpochCallback
 from allennlp.training.trainer import BatchCallback
 from oos_detect.utilities.wandb_loggers import LogMetricsToWandb
 from oos_detect.utilities.wandb_loggers import LogBatchMetricsToWandb
+from allennlp.data.token_indexers import PretrainedTransformerIndexer
 
 
 def build_epoch_callbacks(wbrun) -> EpochCallback:
@@ -43,6 +44,26 @@ def build_vocab(
     # log.debug("Building the vocabulary.")
     print(f"Adding {len(instances)} instances data to vocab.")
     vocab = Vocabulary.from_instances(instances)
+
+    return vocab
+
+
+# HACK: Temporary inelegant solution; until release brings fix
+# (PR: #4958).
+def build_vocab_and_apply_transformer_vocab(
+        instances: Iterable[Instance],
+        indexer: PretrainedTransformerIndexer
+) -> Vocabulary:
+    """
+    Build the Vocabulary object from the instances.
+    Also calls indexer._add_encoding_to_vocabulary_if_needed() on
+    the vocab.
+
+    :param instances: Iterable of allennlp instances.
+    :return Vocabulary: The Vocabulary object.
+    """
+    vocab = build_vocab(instances)
+    indexer._add_encoding_to_vocabulary_if_needed(vocab)
 
     return vocab
 

--- a/oos_detect/models/builders.py
+++ b/oos_detect/models/builders.py
@@ -5,10 +5,10 @@ from allennlp.data import Vocabulary
 from allennlp.data import DataLoader
 from typing import Any, Tuple, Iterable
 from allennlp.training.trainer import Trainer
-from allennlp.data import MultiProcessDataLoader
 from allennlp.training.trainer import TrainerCallback
 from oos_detect.train.callbacks import LogMetricsToWandb
 from allennlp.training.trainer import GradientDescentTrainer
+from allennlp.data.data_loaders import MultiProcessDataLoader
 from allennlp.training.optimizers import HuggingfaceAdamWOptimizer
 
 

--- a/oos_detect/models/builders.py
+++ b/oos_detect/models/builders.py
@@ -41,8 +41,10 @@ def build_vocab(
     :return Vocabulary: The Vocabulary object.
     """
     # log.debug("Building the vocabulary.")
+    print(f"Adding {len(instances)} instances data to vocab.")
+    vocab = Vocabulary.from_instances(instances)
 
-    return Vocabulary.from_instances(instances)
+    return vocab
 
 
 def build_data_loader(

--- a/oos_detect/models/builders.py
+++ b/oos_detect/models/builders.py
@@ -1,69 +1,52 @@
 import torch
 from allennlp.models import Model
+from allennlp.data import Instance
 from allennlp.data import Vocabulary
 from allennlp.data import DataLoader
 from typing import Any, Tuple, Iterable
-from allennlp.data import PyTorchDataLoader
-from allennlp.data import DatasetReader, Instance
-from allennlp.training.trainer import EpochCallback
-from allennlp.training.trainer import BatchCallback
-from oos_detect.utilities.wandb_loggers import LogMetricsToWandb
-from oos_detect.utilities.wandb_loggers import LogBatchMetricsToWandb
-from allennlp.data.token_indexers import PretrainedTransformerIndexer
+from allennlp.training.trainer import Trainer
+from allennlp.data import MultiProcessDataLoader
+from allennlp.training.trainer import TrainerCallback
+from oos_detect.train.callbacks import LogMetricsToWandb
+from allennlp.training.trainer import GradientDescentTrainer
+from allennlp.training.optimizers import HuggingfaceAdamWOptimizer
 
 
-def build_epoch_callbacks(wbrun) -> EpochCallback:
+def build_callbacks(wbrun) -> TrainerCallback:
     """
     Instantiate callback - factory method.
 
+    :param wbrun: WandB object.
     :return LogMetricsToWandb: Instantiated LogMetricsToWandb object.
     """
 
     return [LogMetricsToWandb(wbrun=wbrun)]
 
 
-def build_batch_callbacks(wbrun) -> BatchCallback:
-    """
-    Instantiate callback - factory method.
-
-    :return LogBatchMetricsToWandb: Instantiated LogBatchMetricsToWandb object.
-    """
-
-    return [LogBatchMetricsToWandb(wbrun=wbrun)]
-
-
 def build_vocab(
-        instances: Iterable[Instance]
+        instances: Iterable[Instance],
+        from_transformer: bool = False
 ) -> Vocabulary:
     """
-    Build the Vocabulary object from the instances.
+    Build the Vocabulary object from the instances only,
+    or from the pretrained transformer, based on boolean flag
 
     :param instances: Iterable of allennlp instances.
+    :param from_transformer: Whether to initialize vocab from
+                             pretrained transformer, or from
+                             instances directly.
     :return Vocabulary: The Vocabulary object.
     """
     # log.debug("Building the vocabulary.")
     print(f"Adding {len(instances)} instances data to vocab.")
-    vocab = Vocabulary.from_instances(instances)
 
-    return vocab
-
-
-# HACK: Temporary inelegant solution; until release brings fix
-# (PR: #4958).
-def build_vocab_and_apply_transformer_vocab(
-        instances: Iterable[Instance],
-        indexer: PretrainedTransformerIndexer
-) -> Vocabulary:
-    """
-    Build the Vocabulary object from the instances.
-    Also calls indexer._add_encoding_to_vocabulary_if_needed() on
-    the vocab.
-
-    :param instances: Iterable of allennlp instances.
-    :return Vocabulary: The Vocabulary object.
-    """
-    vocab = build_vocab(instances)
-    indexer._add_encoding_to_vocabulary_if_needed(vocab)
+    if from_transformer:
+        vocab = Vocabulary.from_pretrained_transformer(
+            model_name="bert-base-uncased"
+        )
+        vocab.extend_from_instances(instances)
+    else:
+        vocab = Vocabulary.from_instances(instances)
 
     return vocab
 
@@ -85,7 +68,7 @@ def build_data_loader(
     # We need to get the allennlp-specific collate function, which is
     # what actually does indexing and batching.
     # log.debug("Building DataLoader.")
-    loader = PyTorchDataLoader(
+    loader = MultiProcessDataLoader(
         data,
         batch_size=batch_size,
         shuffle=True
@@ -122,3 +105,47 @@ def build_train_data_loaders(
     # log.debug("Training DataLoaders built.")
 
     return train_loader, dev_loader
+
+
+def build_grad_desc_with_adam_trainer(
+        model: Model,
+        serialization_dir: str,
+        train_loader: DataLoader,
+        dev_loader: DataLoader,
+        lr: float,
+        num_epochs: int,
+        wbrun: Any = None
+) -> Trainer:
+    """
+    Build the model trainer.
+    Includes instantiating the optimizer as well.
+    This builder uses the GradientDescentTrainer &
+    HuggingfaceAdamWOptimizer combo.
+    Also allows setting callbacks (atm for WandB mainly).
+
+    :param model: The model object to be trained.
+    :param serialization_dir: The serialization directory to output
+            results to.
+    :param train_loader: The training data loader.
+    :param dev_loader: The dev data loader.
+    :param lr: Learning rate.
+    :param num_epochs: Number of epochs to train for.
+    :param wbrun: WandB object to use for callbacks.
+    :return trainer: The Trainer object.
+    """
+    parameters = [
+        [n, p]
+        for n, p in model.named_parameters() if p.requires_grad
+    ]
+    optimizer = HuggingfaceAdamWOptimizer(parameters, lr=lr)
+    trainer = GradientDescentTrainer(
+        model=model,
+        serialization_dir=serialization_dir,
+        data_loader=train_loader,
+        validation_data_loader=dev_loader,
+        num_epochs=num_epochs,
+        optimizer=optimizer,
+        callbacks=build_callbacks(wbrun) if wbrun else None
+    )
+
+    return trainer

--- a/oos_detect/train/__main__.py
+++ b/oos_detect/train/__main__.py
@@ -13,7 +13,7 @@ from oos_detect.train.run import run_training
 from oos_detect.train.metrics import get_metrics
 from oos_detect.train.predict import get_predictions
 from oos_detect.datasets.readers.oos_eval import OOSEvalReader
-from oos_detect.datasets.readers.oos_eval import read_oos_data
+from oos_detect.datasets.readers.oos_eval import oos_data_paths
 from oos_detect.models.bert_linear.builders import bert_linear_builders
 # from pseudo_ood_generation.components.ae.builders import pog_ae_builders
 
@@ -37,34 +37,33 @@ def train_test_pred(
         model_name="dunkrun",
 ):
     hyperparams = {
-        "epochs": 3,
+        "num_epochs": 3,
         "batch_size": 64,
         "lr": 0.0001,
         "no_cuda": False,
         "log_interval": 10
     }
-    dataset_reader = OOSEvalReader()
-    train_data, test_data = read_oos_data(
-        reader=dataset_reader,
-        set=set
-    )
+    data_reader = OOSEvalReader()
+    train_paths, test_path = oos_data_paths(set=set)
 
     # pp = pprint.PrettyPrinter(indent=4)
     model = run_training(
-        data=train_data,
+        data_reader=data_reader,
+        data_paths=train_paths,
         model_builder=builders,
         run_name=(model_name + "_" + set),
         hyperparams=hyperparams
     )
 
     if run_test:
-        model = run_testing(test_data, model)
+        model = run_testing(test_path, model)
 
+    # TODO: check test path param.
     if get_preds:
         actuals, predictions, labels = get_predictions(
             model,
-            dataset_reader,
-            list(test_data)
+            data_reader,
+            list(test_path)
         )
 
         return actuals, predictions, labels

--- a/oos_detect/train/__main__.py
+++ b/oos_detect/train/__main__.py
@@ -56,14 +56,17 @@ def train_test_pred(
     )
 
     if run_test:
-        model = run_testing(test_path, model)
+        model = run_testing(
+            data_reader=data_reader,
+            data_path=test_path,
+            model=model
+        )
 
-    # TODO: check test path param.
     if get_preds:
         actuals, predictions, labels = get_predictions(
-            model,
-            data_reader,
-            list(test_path)
+            data_reader=data_reader,
+            data_path=test_path,
+            model=model
         )
 
         return actuals, predictions, labels
@@ -71,10 +74,12 @@ def train_test_pred(
     return
 
 
-train_test_pred(
+actuals, predictions, labels = train_test_pred(
     set="small",
     model_name="bert_linear",
-    builders=bert_linear_builders
+    builders=bert_linear_builders,
+    run_test=True,
+    get_preds=True
 )
 
 
@@ -83,8 +88,8 @@ train_test_pred(
     model_name="pog_ae",
     builders=pog_ae_builders
 )"""
-# df = get_metrics(actuals, predictions, labels)
+df = get_metrics(actuals, predictions, labels)
 
-# with pd.option_context('display.max_rows', None):
-#    print("\n\n=====   Multiclass Classification Report   =====")
-#    print(df)
+with pd.option_context('display.max_rows', None):
+    print("\n\n=====   Multiclass Classification Report   =====")
+    print(df)

--- a/oos_detect/train/__main__.py
+++ b/oos_detect/train/__main__.py
@@ -14,7 +14,8 @@ from oos_detect.train.metrics import get_metrics
 from oos_detect.train.predict import get_predictions
 from oos_detect.datasets.readers.oos_eval import OOSEvalReader
 from oos_detect.datasets.readers.oos_eval import read_oos_data
-from pseudo_ood_generation.components.ae.builders import pog_ae_builders
+from oos_detect.models.bert_linear.builders import bert_linear_builders
+# from pseudo_ood_generation.components.ae.builders import pog_ae_builders
 
 
 # Logger setup.
@@ -45,7 +46,8 @@ def train_test_pred(
     model = run_training(
         data=train_data,
         model_builder=builders,
-        run_name=(model_name + "_" + set)
+        run_name=(model_name + "_" + set),
+        transformer_indexer=dataset_reader.token_indexers["tokens"]
     )
 
     if run_test:
@@ -65,9 +67,16 @@ def train_test_pred(
 
 train_test_pred(
     set="small",
+    model_name="bert_linear",
+    builders=bert_linear_builders
+)
+
+
+"""train_test_pred(
+    set="small",
     model_name="pog_ae",
     builders=pog_ae_builders
-)
+)"""
 # df = get_metrics(actuals, predictions, labels)
 
 # with pd.option_context('display.max_rows', None):

--- a/oos_detect/train/__main__.py
+++ b/oos_detect/train/__main__.py
@@ -65,7 +65,7 @@ def train_test_pred(
 
 train_test_pred(
     set="small",
-    model_name="pog_autoencoder",
+    model_name="pog_ae",
     builders=pog_ae_builders
 )
 # df = get_metrics(actuals, predictions, labels)

--- a/oos_detect/train/__main__.py
+++ b/oos_detect/train/__main__.py
@@ -36,6 +36,13 @@ def train_test_pred(
         set="full",
         model_name="dunkrun",
 ):
+    hyperparams = {
+        "epochs": 3,
+        "batch_size": 64,
+        "lr": 0.0001,
+        "no_cuda": False,
+        "log_interval": 10
+    }
     dataset_reader = OOSEvalReader()
     train_data, test_data = read_oos_data(
         reader=dataset_reader,
@@ -47,7 +54,7 @@ def train_test_pred(
         data=train_data,
         model_builder=builders,
         run_name=(model_name + "_" + set),
-        transformer_indexer=dataset_reader.token_indexers["tokens"]
+        hyperparams=hyperparams
     )
 
     if run_test:

--- a/oos_detect/train/callbacks.py
+++ b/oos_detect/train/callbacks.py
@@ -2,8 +2,8 @@ import torch
 from typing import Any, List, Dict
 from allennlp.training.trainer import Trainer
 from allennlp.training.trainer import TrainerCallback
-from utilities.exceptions import UnskippableSituationError
 from allennlp.data.data_loaders.data_loader import TensorDict
+from oos_detect.utilities.exceptions import UnskippableSituationError
 
 
 class LogMetricsToWandb(TrainerCallback):

--- a/oos_detect/train/callbacks.py
+++ b/oos_detect/train/callbacks.py
@@ -1,5 +1,6 @@
 import torch
-from typing import Any, List, Dict
+from pathlib import Path
+from typing import Any, List, Dict, Optional
 from allennlp.training.trainer import Trainer
 from allennlp.training.trainer import TrainerCallback
 from allennlp.data.data_loaders.data_loader import TensorDict
@@ -9,12 +10,13 @@ from oos_detect.utilities.exceptions import UnskippableSituationError
 class LogMetricsToWandb(TrainerCallback):
     def __init__(
             self,
+            serialization_dir: Path,
             wbrun: Any,
             epoch_end_log_freq: int = 1
     ) -> None:
         # import wandb here to be sure that it was initialized
         # before this line was executed
-        super().__init__()
+        super().__init__(serialization_dir)
         # import wandb  # type: ignore
 
         self.wandb = wbrun
@@ -43,7 +45,8 @@ class LogMetricsToWandb(TrainerCallback):
         epoch: int,
         batch_number: int,
         is_training: bool,
-        is_primary: bool
+        is_primary: bool,
+        batch_grad_norm: Optional[float] = None,
     ) -> None:
         """
         This should run after all the epoch end metrics have

--- a/oos_detect/train/callbacks.py
+++ b/oos_detect/train/callbacks.py
@@ -2,7 +2,7 @@ import torch
 from typing import Any, List, Dict
 from allennlp.training.trainer import Trainer
 from allennlp.training.trainer import TrainerCallback
-from utils.exceptions import UnskippableSituationError
+from utilities.exceptions import UnskippableSituationError
 from allennlp.data.data_loaders.data_loader import TensorDict
 
 

--- a/oos_detect/train/callbacks.py
+++ b/oos_detect/train/callbacks.py
@@ -1,15 +1,12 @@
 import torch
-import logging.config
-from typing import Any, List, Dict, Optional
+from typing import Any, List, Dict
 from allennlp.training.trainer import Trainer
 from allennlp.data.dataloader import TensorDict
-from allennlp.training.trainer import EpochCallback, BatchCallback
-
-# Logger setup.
-log = logging.getLogger(__name__)
+from allennlp.training.trainer import TrainerCallback
+from utils.exceptions import UnskippableSituationError
 
 
-class LogBatchMetricsToWandb(BatchCallback):
+class LogMetricsToWandb(TrainerCallback):
     def __init__(
             self,
             wbrun: Any,
@@ -20,28 +17,24 @@ class LogBatchMetricsToWandb(BatchCallback):
         super().__init__()
         # import wandb  # type: ignore
 
-        self.config: Optional[Dict[str, Any]] = None
-
         self.wandb = wbrun
+        self.config = self.wandb.config
+
         self.batch_end_log_freq = 1
+        self.epoch_end_log_freq = 1
+
         self.current_batch_num = -1
+        self.current_epoch_num = -1
+
         self.previous_logged_batch = -1
+        self.previous_logged_epoch = -1
 
     def update_config(self, trainer: Trainer) -> None:
         if self.config is None:
-            # we assume that allennlp train pipeline would have written
-            # the entire config to the file by this time
-            log.info("Updating config in callback init...")
-            wbconf = {}
-            wbconf["batch_size"] = 64
-            wbconf["lr"] = 0.0001
-            wbconf["num_epochs"] = 3
-            wbconf["no_cuda"] = False
-            wbconf["log_interval"] = 10
-            self.config = wbconf
-            self.wandb.config.update(self.config)
+            print("Config is none. How did this happen?")
+            raise UnskippableSituationError()
 
-    def __call__(
+    def on_batch(
         self,
         trainer: Trainer,
         batch_inputs: List[List[TensorDict]],
@@ -50,7 +43,7 @@ class LogBatchMetricsToWandb(BatchCallback):
         epoch: int,
         batch_number: int,
         is_training: bool,
-        is_master: bool
+        is_primary: bool
     ) -> None:
         """
         This should run after all the epoch end metrics have
@@ -61,12 +54,10 @@ class LogBatchMetricsToWandb(BatchCallback):
 
         self.current_batch_num += 1
 
-        if (is_master
+        if (is_primary
                 and (self.current_batch_num - self.previous_logged_batch)
                 >= self.batch_end_log_freq):
-            # print("Writing metrics for the batch to wandb.")
-            # print(f"Batch outputs are: {batch_outputs!r}")
-            # print(f"Batch metrics are: {batch_metrics!r}")
+            print("Writing metrics for the batch to wandb.")
 
             batch_outputs = [{
                 key: value.cpu()
@@ -83,46 +74,12 @@ class LogBatchMetricsToWandb(BatchCallback):
             )
             self.previous_logged_batch = self.current_batch_num
 
-
-class LogMetricsToWandb(EpochCallback):
-    def __init__(
-            self,
-            wbrun: Any,
-            epoch_end_log_freq: int = 1
-    ) -> None:
-        # import wandb here to be sure that it was initialized
-        # before this line was executed
-        super().__init__()
-        # import wandb  # type: ignore
-
-        self.config: Optional[Dict[str, Any]] = None
-
-        self.wandb = wbrun
-        self.epoch_end_log_freq = 1
-        self.current_batch_num = -1
-        self.current_epoch_num = -1
-        self.previous_logged_epoch = -1
-
-    def update_config(self, trainer: Trainer) -> None:
-        if self.config is None:
-            # we assume that allennlp train pipeline would have written
-            # the entire config to the file by this time
-            log.info("Updating config in callback init...")
-            wbconf = {}
-            wbconf["batch_size"] = 64
-            wbconf["lr"] = 0.0001
-            wbconf["num_epochs"] = 3
-            wbconf["no_cuda"] = False
-            wbconf["log_interval"] = 10
-            self.config = wbconf
-            self.wandb.config.update(self.config)
-
-    def __call__(
+    def on_epoch(
             self,
             trainer: Trainer,
             metrics: Dict[str, Any],
             epoch: int,
-            is_master: bool,
+            is_primary: bool,
     ) -> None:
         """ This should run after all the epoch end metrics have
         been computed by the metric_tracker callback.
@@ -133,7 +90,7 @@ class LogMetricsToWandb(EpochCallback):
 
         self.current_epoch_num += 1
 
-        if (is_master
+        if (is_primary
                 and (self.current_epoch_num - self.previous_logged_epoch)
                 >= self.epoch_end_log_freq):
             # print("Writing metrics for the epoch to wandb.")

--- a/oos_detect/train/callbacks.py
+++ b/oos_detect/train/callbacks.py
@@ -1,9 +1,9 @@
 import torch
 from typing import Any, List, Dict
 from allennlp.training.trainer import Trainer
-from allennlp.data.dataloader import TensorDict
 from allennlp.training.trainer import TrainerCallback
 from utils.exceptions import UnskippableSituationError
+from allennlp.data.data_loaders.data_loader import TensorDict
 
 
 class LogMetricsToWandb(TrainerCallback):

--- a/oos_detect/train/predict.py
+++ b/oos_detect/train/predict.py
@@ -3,11 +3,12 @@ from oos_detect.utilities.locate import locate_oos_data
 from allennlp.predictors import TextClassifierPredictor
 
 
-def get_predictions(model, dataset_reader, data):
+def get_predictions(model, data_reader, data_path):
     predictor = TextClassifierPredictor(
         model=model,
-        dataset_reader=dataset_reader
+        dataset_reader=data_reader
     )
+    data = list(data_reader.read(data_path))
 
     size = len(data)
     bound = 4000
@@ -16,7 +17,7 @@ def get_predictions(model, dataset_reader, data):
     if size > bound:
         times = int(size/bound)
         print(f"Set is too big; total size: {size}. "
-                f"Batching {times} times.")
+              f"Batching {times} times.")
 
         for i in range(times):
             print(f"Lower: {bound*i}, Upper: {bound*(i + 1)}")
@@ -32,7 +33,10 @@ def get_predictions(model, dataset_reader, data):
 
     labelmap = predictor._model.vocab.get_index_to_token_vocabulary('labels')
 
-    predictions = [labelmap[np.argmax(l['probs'])] for l in preds]
+    predictions = [
+        labelmap[np.argmax(lst['probs'])]
+        for lst in preds
+    ]
     actuals = [str(i['label'].label) for i in data]
     labels = list(labelmap.values())
 

--- a/oos_detect/train/run.py
+++ b/oos_detect/train/run.py
@@ -41,6 +41,7 @@ def run_training(
     print(f"Example training instance: {train_data[0]}.")
 
     vocab = build_vocab(train_data + dev_data)
+    print(f"Vocab size: {vocab.get_index_to_token_vocabulary()}")
 
     # This is the allennlp-specific functionality in the Dataset object;
     # we need to be able convert strings in the data to integers, and

--- a/oos_detect/utilities/exceptions.py
+++ b/oos_detect/utilities/exceptions.py
@@ -20,3 +20,10 @@ class ReqdFileNotInSetError(Error):
     Raised when the file asked for does not exist in the dataset.
     """
     pass
+
+
+class UnskippableSituationError(Error):
+    """
+    Raised when control flow must intentionally be stopped.
+    """
+    pass

--- a/oos_detect/utilities/locate.py
+++ b/oos_detect/utilities/locate.py
@@ -14,12 +14,13 @@ def locate_oos_data() -> Path:
     """
     log.debug("Locating CLINC data directory.")
     path = (Path(__file__).parent.parent
-            .absolute()/"datasets/oos-eval/data")
+            .absolute()/"datasets/oos_eval/data")
+    print(path)
 
     if path.is_dir():
         return path
     else:
-        log.debug("Failed! Path not resolved, or is not a file.")
+        print("Failed! Path not resolved, or is not a file.")
 
     return
 
@@ -41,7 +42,8 @@ def locate_results_dir() -> Path:
     if path.exists():
         return path
     else:
-        log.debug("Failed! Please create the directory "
-                  "oos-detect/train/results.")
+        # add code to mkdir a results dir.
+        print("Failed! Please create the directory "
+              "oos-detect/train/results.")
 
     return

--- a/oos_detect/utilities/wandb_loggers.py
+++ b/oos_detect/utilities/wandb_loggers.py
@@ -35,7 +35,7 @@ class LogBatchMetricsToWandb(BatchCallback):
             wbconf = {}
             wbconf["batch_size"] = 64
             wbconf["lr"] = 0.0001
-            wbconf["num_epochs"] = 2
+            wbconf["num_epochs"] = 3
             wbconf["no_cuda"] = False
             wbconf["log_interval"] = 10
             self.config = wbconf
@@ -111,7 +111,7 @@ class LogMetricsToWandb(EpochCallback):
             wbconf = {}
             wbconf["batch_size"] = 64
             wbconf["lr"] = 0.0001
-            wbconf["num_epochs"] = 2
+            wbconf["num_epochs"] = 3
             wbconf["no_cuda"] = False
             wbconf["log_interval"] = 10
             self.config = wbconf


### PR DESCRIPTION
### #changelog
---

- Fixes issue with vocab.
  - Former vocab setup would contain only a single namespace called `labels`; `tokens` namespace was being omitted.
  - Current setup, after `allennlp==2.1.0`, uses `Vocabulary.from_pretrained_transformer` to initialize the vocab with the `tokens` namespace prior to being extended by the instance list.
- Top-level `hyperparams` `dict` used, instead of changes being made all over the place; doubles as WandB config `dict`.
- Makes updates overall to accommodate breaking changes made by `allennlp==2.1.0`
  - Uses `MultiProcessDataLoader` according to [this guide](https://github.com/allenai/allennlp/discussions/4933).
    - Updates `DatasetReader` to enable sharding for multiple workers.
      - Also moves indexer application to the `Instance` objects to a separate function.
    - Uses a single `TrainerCallback` instead of `EpochCallback` & `BatchCallback`. 
    - `read_` utility functions in `OOSEvalReader` changed to path retrieval methods, since `MultiProcessDataLoader` needs the `DatasetReader` object and data path, instead of an iterable of instances (`AllennlpDataset`) as before.
      - Accordingly, vocab is no longer instantiated from instances directly read from `DatasetReader`, instead being extended by an iterable of instances returned by `MultiProcessDataLoader.iter_instances()`.
    - Additionally, test/predict functions updated to accommodate above changes as well.
- Added a new `Error` type for intentional stops at unusual situations; will be replaced in a future version.